### PR TITLE
Keep analysis results visible when clicking on issues for better UX

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -438,8 +438,8 @@
             message.hasSelection
           );
           
-          // Hide previous results when selection changes
-          resultsContainer.classList.remove('visible');
+          // Keep results visible so users can continue clicking on issues
+          // resultsContainer.classList.remove('visible');
           break;
           
         case 'analysis-complete':


### PR DESCRIPTION
When tapping on a result, the results will persist and the plugin does not reset itself.